### PR TITLE
Fix: error cannot find module 'react', npm i @types/react

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
       "devDependencies": {
         "@eslint/js": "^9.9.0",
         "@types/node": "^22.5.4",
-        "@types/react": "^18.3.3",
+        "@types/react": "^18.3.5",
         "@types/react-dom": "^18.3.0",
         "@vitejs/plugin-react-swc": "^3.5.0",
         "autoprefixer": "^10.4.20",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "@eslint/js": "^9.9.0",
     "@types/node": "^22.5.4",
-    "@types/react": "^18.3.3",
+    "@types/react": "^18.3.5",
     "@types/react-dom": "^18.3.0",
     "@vitejs/plugin-react-swc": "^3.5.0",
     "autoprefixer": "^10.4.20",


### PR DESCRIPTION
When importing react module to a component, error message "error cannot find module 'react'" occurred.